### PR TITLE
Allow docusign-rest-client ^6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "php": "^7.3 | ^8.0",
     "illuminate/support": "~6.0|~7.0|~8.0|~9.0|~10.0|~11.0|~12.0",
-    "tucker-eric/docusign-rest-client": "~2.0|~3.0|~4.0|~5.0"
+    "tucker-eric/docusign-rest-client": "~2.0|~3.0|~4.0|~5.0|~6.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Pairs with the PR widening esign-client to ^7/^8 in docusign-rest-client, so the chain can install the adhocore/jwt-based esign-client v8 and drop the flagged firebase/php-jwt transitive dependency.